### PR TITLE
Make BLEServiceData public

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,6 @@
 mod ble_advertised_device;
 pub use self::ble_advertised_device::BLEAdvertisedDevice;
+pub use self::ble_advertised_device::BLEServiceData;
 
 mod ble_attribute;
 pub(crate) use self::ble_attribute::*;


### PR DESCRIPTION
Make the BLEServiceData struct public, so that advertised data can be accessed by an application.
