### PR TITLE
Update esp-rs crates dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32-nimble"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["taks <857tn859@gmail.com>"]
 edition = "2021"
 resolver = "2"
@@ -23,22 +23,22 @@ opt-level = "z"
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-esp-idf-sys = { version = "0.32.0", default-features = false }
-esp-idf-hal = { version = "0.40.0", default-features = false, features = ["critical-section", "embassy-sync"] }
-esp-idf-svc = { version = "0.45.0", default-features = false, features = ["alloc"] }
-embedded-svc = { version = "0.24.0", default-features = false }
+esp-idf-sys = { version = "0.33", default-features = false }
+esp-idf-hal = { version = "0.41", default-features = false, features = ["critical-section", "embassy-sync"] }
+esp-idf-svc = { version = "0.46", default-features = false, features = ["alloc"] }
+embedded-svc = { version = "0.25", default-features = false }
 
 bitflags = { version = "1.3.2" }
 critical-section = { version = "1.1.1" }
-embassy-sync = { version = "0.1.0" }
+embassy-sync = { version = "0.2.0" }
 once_cell = { version = "1.16.0", default-features = false, features = ["critical-section"] }
 uuid = { version = "1.2.2", default-features = false, features = ["macro-diagnostics"] }
 
 [dev-dependencies]
-esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "alloc_handler"] }
-esp-idf-hal = { version = "0.40.1", default-features = false, features = ["critical-section", "edge-executor", "embassy-sync"] }
-esp-idf-svc = { version = "0.45.0", default-features = false, features = ["alloc", "embassy-time-driver", "embassy-time-isr-queue"] }
-embedded-hal = { version = "=1.0.0-alpha.9", default-features = false }
+esp-idf-sys = { version = "0.33", default-features = false, features = ["binstart", "alloc_handler"] }
+esp-idf-hal = { version = "0.41", default-features = false, features = ["critical-section", "edge-executor", "embassy-sync"] }
+esp-idf-svc = { version = "0.46", default-features = false, features = ["alloc", "embassy-time-driver", "embassy-time-isr-queue"] }
+embedded-hal = { version = "=1.0.0-alpha.10", default-features = false }
 thingbuf = { version = "0.1.3", default-features = false, features = ["alloc"] }
 embassy-time = { version = "0.1", features = ["tick-hz-1_000_000"] }
 

--- a/src/utilities/mutex.rs
+++ b/src/utilities/mutex.rs
@@ -45,7 +45,6 @@ unsafe impl Sync for RawMutex {}
 unsafe impl Send for RawMutex {}
 
 impl embedded_svc::utils::mutex::RawMutex for RawMutex {
-  #[cfg(feature = "nightly")] // Remove "nightly" condition once 1.64 is out
   #[allow(clippy::declare_interior_mutable_const)]
   const INIT: Self = RawMutex::new();
 


### PR DESCRIPTION
Updated cargo esp-rs crates dependencies.

I found that when generating a new project using https://github.com/esp-rs/esp-idf-template template, I was unable to build the project because new versions of the esp-rs crates were already in use. This PR fixes this.