### PR TITLE
allow to convert uuid::Uuid value to BleUuid

### DIFF
--- a/src/utilities/ble_uuid.rs
+++ b/src/utilities/ble_uuid.rs
@@ -156,7 +156,7 @@ impl core::fmt::Debug for BleUuid {
 
 impl From<uuid::Uuid> for BleUuid {
   fn from(uuid: uuid::Uuid) -> Self {
-    let mut bytes = uuid.as_bytes().clone();
+    let mut bytes = *uuid.as_bytes();
     bytes.reverse();
     Self::Uuid128(bytes)
   }

--- a/src/utilities/ble_uuid.rs
+++ b/src/utilities/ble_uuid.rs
@@ -156,7 +156,9 @@ impl core::fmt::Debug for BleUuid {
 
 impl From<uuid::Uuid> for BleUuid {
   fn from(uuid: uuid::Uuid) -> Self {
-    Self::Uuid128(uuid.into_bytes())
+    let mut bytes = uuid.as_bytes().clone();
+    bytes.reverse();
+    Self::Uuid128(bytes)
   }
 }
 

--- a/src/utilities/ble_uuid.rs
+++ b/src/utilities/ble_uuid.rs
@@ -154,6 +154,12 @@ impl core::fmt::Debug for BleUuid {
   }
 }
 
+impl From<uuid::Uuid> for BleUuid {
+  fn from(uuid: uuid::Uuid) -> Self {
+    Self::Uuid128(uuid.into_bytes())
+  }
+}
+
 #[macro_export]
 /// Parse Uuid128 from string literals at compile time.
 macro_rules! uuid128 {


### PR DESCRIPTION
Implement the  `From<uuid::Uuid>` trait for BleUuid to allow usage of those uuids by calling into().
In my case i have a common lib used by a client and the esp32. The client library uses the uuid lib for it's ble service/characteristic ids. By implementing this i can now use a common uuid:Uuid value and pass it to nimble functions by calling into()