### PR TITLE
Add feature for building with std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           RUSTFLAGS: "${{ matrix.rustflags }}"
-        run: cargo build --target ${{ matrix.target }} ${{ matrix.build-options }}
+        run: cargo build --target ${{ matrix.target }} ${{ matrix.build-options }} --no-default-features --features "no_std"
       - name: Fmt check
         run: cargo fmt --check
       - name: Clippy check
         env:
           ESP_IDF_VERSION: ${{ matrix.idf-version }}
           RUSTFLAGS: "${{ matrix.rustflags }}"
-        run: cargo clippy --target ${{ matrix.target }} --all-features -- -D clippy::all
+        run: cargo clippy --target ${{ matrix.target }} --no-default-features --features "no_std" -- -D clippy::all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,14 @@ debug = true
 opt-level = "z"
 
 [features]
+default = ["std"]
+no_std = ["esp-idf-hal/critical-section"]
+std = ["esp-idf-svc/std", "esp-idf-hal/std", "critical-section/std"]
 
 [dependencies]
 log = { version = "0.4", default-features = false }
 esp-idf-sys = { version = "0.33", default-features = false }
-esp-idf-hal = { version = "0.42", default-features = false, features = ["critical-section", "embassy-sync"] }
+esp-idf-hal = { version = "0.42", default-features = false, features = ["embassy-sync"] }
 esp-idf-svc = { version = "0.47", default-features = false, features = ["alloc"] }
 embedded-svc = { version = "0.26", default-features = false }
 


### PR DESCRIPTION
Added esp32-nimble into an esp32 std project and failed to build.
That's because critical-section used a built-in critical section implementation when std enabled.
So I think it's better to add a feature in this project to make it work with std.