### PR TITLE
Add notification check and properties to BLE characteristic

### DIFF
--- a/examples/ble_client.rs
+++ b/examples/ble_client.rs
@@ -57,6 +57,11 @@ fn main() {
 
       let uuid = uuid128!("a3c87500-8ed3-4bdf-8a39-a01bebede295");
       let characteristic = service.get_characteristic(uuid).await.unwrap();
+
+      if !characteristic.can_notify() {
+        return ::log::error!("characteristic can't notify: {:?}", uuid);
+      }
+
       ::log::info!("subscribe {:?}", uuid);
       characteristic
         .on_notify(|data| {

--- a/src/client/ble_remote_characteristic.rs
+++ b/src/client/ble_remote_characteristic.rs
@@ -221,6 +221,42 @@ impl BLERemoteCharacteristic {
     self
   }
 
+  pub fn can_notify(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::NOTIFY)
+  }
+
+  pub fn can_indicate(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::INDICATE)
+  }
+
+  pub fn can_read(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::READ)
+  }
+
+  pub fn can_write(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::WRITE)
+  }
+
+  pub fn can_write_no_response(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::WRITE_NO_RSP)
+  }
+
+  pub fn can_broadcast(&self) -> bool {
+    self
+      .properties()
+      .contains(GattCharacteristicProperties::BROADCAST)
+  }
+
   pub(crate) unsafe fn notify(&mut self, om: *mut esp_idf_sys::os_mbuf) {
     if let Some(no_notify) = self.state.on_notify.as_mut() {
       let data = unsafe { core::slice::from_raw_parts((*om).om_data, (*om).om_len as _) };


### PR DESCRIPTION
Aligned the API with h2zero/NimBLE-Arduino, namely: [NimBLE-Arduino RemoteCharacteristic](https://github.com/h2zero/NimBLE-Arduino/blob/bc333ccb6e8d9ff2059af9cbd5006a290a4de3a5/src/NimBLERemoteCharacteristic.cpp#L106).