### PR TITLE
Streamlined BLE Device Scanning Process

### DIFF
--- a/examples/ble_client.rs
+++ b/examples/ble_client.rs
@@ -1,6 +1,5 @@
 use esp32_nimble::{uuid128, BLEClient, BLEDevice};
 use bstr::ByteSlice;
-use esp32_nimble::{utilities::mutex::Mutex, uuid128, BLEClient, BLEDevice};
 use esp_idf_hal::prelude::Peripherals;
 use esp_idf_hal::task::block_on;
 use esp_idf_hal::timer::{TimerConfig, TimerDriver};

--- a/examples/ble_client.rs
+++ b/examples/ble_client.rs
@@ -1,5 +1,5 @@
-use esp32_nimble::{uuid128, BLEClient, BLEDevice};
 use bstr::ByteSlice;
+use esp32_nimble::{uuid128, BLEClient, BLEDevice};
 use esp_idf_hal::prelude::Peripherals;
 use esp_idf_hal::task::block_on;
 use esp_idf_hal::timer::{TimerConfig, TimerDriver};
@@ -15,7 +15,7 @@ fn main() {
   block_on(async {
     let ble_device = BLEDevice::take();
     let ble_scan = ble_device.get_scan();
-     let device = ble_scan
+    let device = ble_scan
       .active_scan(true)
       .interval(100)
       .window(99)

--- a/examples/ble_secure_client.rs
+++ b/examples/ble_secure_client.rs
@@ -1,8 +1,4 @@
-use esp32_nimble::{
-  enums::*,
-  utilities::BleUuid,
-  BLEClient, BLEDevice,
-};
+use esp32_nimble::{enums::*, utilities::BleUuid, BLEClient, BLEDevice};
 use esp_idf_hal::task::block_on;
 use esp_idf_sys as _;
 use log::*;
@@ -29,7 +25,9 @@ fn main() {
       .active_scan(true)
       .interval(100)
       .window(99)
-      .find_device(10000, move |device| device.is_advertising_service(&SERVICE_UUID))
+      .find_device(10000, move |device| {
+        device.is_advertising_service(&SERVICE_UUID)
+      })
       .await
       .unwrap();
 

--- a/examples/ble_secure_client.rs
+++ b/examples/ble_secure_client.rs
@@ -1,12 +1,11 @@
 use esp32_nimble::{
   enums::*,
-  utilities::{mutex::Mutex, BleUuid},
+  utilities::BleUuid,
   BLEClient, BLEDevice,
 };
 use esp_idf_hal::task::block_on;
 use esp_idf_sys as _;
 use log::*;
-use std::sync::Arc;
 
 const SERVICE_UUID: BleUuid = BleUuid::Uuid16(0xABCD);
 
@@ -25,22 +24,14 @@ fn main() {
       .set_io_cap(SecurityIOCap::KeyboardOnly);
 
     let ble_scan = device.get_scan();
-    let connect_device = Arc::new(Mutex::new(None));
 
-    let device0 = connect_device.clone();
-    ble_scan
+    let device = ble_scan
       .active_scan(true)
       .interval(100)
       .window(99)
-      .on_result(move |scan, device| {
-        if device.is_advertising_service(&SERVICE_UUID) {
-          scan.stop().unwrap();
-          (*device0.lock()) = Some(device.clone());
-        }
-      });
-    ble_scan.start(10000).await.unwrap();
-
-    let device = &*connect_device.lock();
+      .find_device(10000, move |device| device.is_advertising_service(&SERVICE_UUID))
+      .await
+      .unwrap();
 
     let Some(device) = device else {
       ::log::warn!("device not found");

--- a/src/client/ble_scan.rs
+++ b/src/client/ble_scan.rs
@@ -1,8 +1,8 @@
+use crate::utilities::mutex::Mutex;
 use crate::{ble, BLEAdvertisedDevice, BLEReturnCode, Signal};
 use alloc::sync::Arc;
 use alloc::{boxed::Box, vec::Vec};
 use core::ffi::c_void;
-use crate::utilities::mutex::Mutex;
 
 pub struct BLEScan {
   #[allow(clippy::type_complexity)]


### PR DESCRIPTION
This PR simplifies the BLE device scanning process.

**Before:**

```rust
let connect_device = Arc::new(Mutex::new(None));
let device0 = connect_device.clone();
scan.on_result(move |scan, device| {
  if device.name().contains("ESP32") {
    scan.stop().unwrap();
    (*device0.lock()) = Some(device.clone());
  }
});

scan.start(10000).await.unwrap();
let device = &*connect_device.lock();
if let Some(device) = device {
  info!("Advertised Device: {:?}", device);
}
```

**After:**

```rust
scan.on_result(|device| {
  if device.name().contains("Shelly") {
    Some(device)
  } else {
    None
  }
});

if let Some(device) = scan.start(10000).await.unwrap() {
  info!("Advertised Device: {:?}", device);
}
```

The device returned by `on_result` is the return value for `start`. I removed the `scan` argument to `on_result`, but I'm happy to add it again.

I'm open to suggestions on how to improve the scan API further :)