### PR TITLE
Configuring for iOS Auto-Reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,29 +19,32 @@ CONFIG_BT_NIMBLE_ENABLED=y
 - To enable Extended advertising, additionally append `CONFIG_BT_NIMBLE_EXT_ADV=y`.<br>
   (For use with ESP32C3, ESP32S3, ESP32H2 ONLY)
 
-### Configuring for iOS Auto-Reconnect
+### Configuring for iOS Auto-Reconnection
 
-For auto-reconnection of iOS devices to a BLE server, specific settings in the `sdkconfig` file and the Rust code are required.
+To enable seamless auto-reconnection of iOS devices with your ESP32 BLE server, you need to adjust settings in both the `sdkconfig` file and your Rust code.
 
 #### Update `sdkconfig`
 
-Add the following line to your `sdkconfig` file:
+Include this line in your `sdkconfig`:
 
 ```
 CONFIG_BT_NIMBLE_NVS_PERSIST=y
 ```
 
-This ensures the persistence of bonding information in the device's non-volatile storage (NVS), allowing iOS devices to automatically reconnect without needing to rebond after a system reset or power cycle.
+Setting `CONFIG_BT_NIMBLE_NVS_PERSIST` to `y` ensures that bonding information is saved in the device's Non-Volatile Storage (NVS). This step is crucial for allowing iOS devices to automatically reconnect without the need for rebonding after the ESP32 has been reset or powered off and on again.
 
-#### Set Device Security Options in Rust
+#### Configure Security Options in Rust Code
 
-In your Rust implementation, set the security options as follows:
+Properly setting the security options in your Rust implementation is key:
 
 ```rust
 device
   .security()
-  .set_auth(AuthReq::Bond) // or .set_auth(AuthReq::Bond | AuthReq:Mitm)
-  .set_io_cap(SecurityIOCap::NoInputNoOutput) // Any option here works
+  .set_auth(AuthReq::Bond) // Bonding enables key storage for reconnection
+  .set_io_cap(SecurityIOCap::NoInputNoOutput) // You can choose any IO capability
+  .resolve_rpa(); // Crucial for managing iOS's dynamic Bluetooth addresses
 ```
 
-Here, `.set_auth(AuthReq::Bond)` is used to enable bonding, which stores security keys for future reconnections. Note that the use of `.set_auth(AuthReq::Sc)` (Secure Connections) prevents iOS from reconnecting.
+- `.set_auth(AuthReq::Bond)` sets up bonding, crucial for storing security keys that enable future automatic reconnections.
+- **Caution**: Avoid `.set_auth(AuthReq::Sc)` (Secure Connections), as it can interfere with the ability of iOS devices to reconnect.
+- `.resolve_rpa()`: This function is essential for adapting to the changing Bluetooth addresses used by iOS devices, a feature known as Resolvable Private Address (RPA). It's vital for maintaining reliable and seamless connections with iOS devices, ensuring that your ESP32 device can recognize and reconnect to an iOS device even when its Bluetooth address changes.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,32 @@ CONFIG_BT_NIMBLE_ENABLED=y
 
 - To enable Extended advertising, additionally append `CONFIG_BT_NIMBLE_EXT_ADV=y`.<br>
   (For use with ESP32C3, ESP32S3, ESP32H2 ONLY)
+
+### Configuring for iOS Auto-Reconnect
+
+For auto-reconnection of iOS devices to a BLE server, specific settings in the `sdkconfig` file and the Rust code are required.
+
+#### Update `sdkconfig`
+
+Add the following line to your `sdkconfig` file:
+
+```
+CONFIG_BT_NIMBLE_NVS_PERSIST=y
+```
+
+This ensures the persistence of bonding information in the device's non-volatile storage (NVS), allowing iOS devices to automatically reconnect without needing to rebond after a system reset or power cycle.
+
+#### Set Device Security Options in Rust
+
+In your Rust implementation, set the security options as follows:
+
+```rust
+device
+  .security()
+  .set_auth(AuthReq::Bond) // or .set_auth(AuthReq::Bond | AuthReq:Mitm)
+  .set_io_cap(SecurityIOCap::NoInputNoOutput)
+```
+
+Here, `.set_auth(AuthReq::Bond)` is used to enable bonding, which stores security keys for future reconnections. Note that the use of `.set_auth(AuthReq::Sc)` (Secure Connections) prevents iOS devices from reconnecting.
+
+The `.set_io_cap(SecurityIOCap::NoInputNoOutput)` setting is important for devices that lack a user interface, ensuring compatibility with a wider range of device types.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ In your Rust implementation, set the security options as follows:
 device
   .security()
   .set_auth(AuthReq::Bond) // or .set_auth(AuthReq::Bond | AuthReq:Mitm)
-  .set_io_cap(SecurityIOCap::NoInputNoOutput)
+  .set_io_cap(SecurityIOCap::NoInputNoOutput) // Any option here works
 ```
 
-Here, `.set_auth(AuthReq::Bond)` is used to enable bonding, which stores security keys for future reconnections. Note that the use of `.set_auth(AuthReq::Sc)` (Secure Connections) prevents iOS devices from reconnecting.
-
-The `.set_io_cap(SecurityIOCap::NoInputNoOutput)` setting is important for devices that lack a user interface, ensuring compatibility with a wider range of device types.
+Here, `.set_auth(AuthReq::Bond)` is used to enable bonding, which stores security keys for future reconnections. Note that the use of `.set_auth(AuthReq::Sc)` (Secure Connections) prevents iOS from reconnecting.

--- a/README.md
+++ b/README.md
@@ -46,5 +46,4 @@ device
 ```
 
 - `.set_auth(AuthReq::Bond)` sets up bonding, crucial for storing security keys that enable future automatic reconnections.
-- **Caution**: Avoid `.set_auth(AuthReq::Sc)` (Secure Connections), as it can interfere with the ability of iOS devices to reconnect.
 - `.resolve_rpa()`: This function is essential for adapting to the changing Bluetooth addresses used by iOS devices, a feature known as Resolvable Private Address (RPA). It's vital for maintaining reliable and seamless connections with iOS devices, ensuring that your ESP32 device can recognize and reconnect to an iOS device even when its Bluetooth address changes.


### PR DESCRIPTION
The configuration options mentioned in the README work reliably for iOS devices. Unfortunately, I don't have any sources to back up my statements, but it works for all my iOS 16 & 17 devices against ESP32 and ESP32C3.