### PR TITLE
Implement Display and Debug traits for BLERemoteCharacteristic & BLERemoteService

### DIFF
--- a/examples/ble_client.rs
+++ b/examples/ble_client.rs
@@ -51,7 +51,7 @@ fn main() {
         return ::log::error!("characteristic can't notify: {}", characteristic);
       }
 
-      ::log::info!("subscribe {}", characteristic);
+      ::log::info!("subscribe to {}", characteristic);
       characteristic
         .on_notify(|data| {
           ::log::info!("{}", core::str::from_utf8(data).unwrap());

--- a/examples/ble_client.rs
+++ b/examples/ble_client.rs
@@ -39,8 +39,8 @@ fn main() {
       let characteristic = service.get_characteristic(uuid).await.unwrap();
       let value = characteristic.read_value().await.unwrap();
       ::log::info!(
-        "{:?} value: {}",
-        uuid,
+        "{} value: {}",
+        characteristic,
         core::str::from_utf8(&value).unwrap()
       );
 
@@ -48,10 +48,10 @@ fn main() {
       let characteristic = service.get_characteristic(uuid).await.unwrap();
 
       if !characteristic.can_notify() {
-        return ::log::error!("characteristic can't notify: {:?}", uuid);
+        return ::log::error!("characteristic can't notify: {}", characteristic);
       }
 
-      ::log::info!("subscribe {:?}", uuid);
+      ::log::info!("subscribe {}", characteristic);
       characteristic
         .on_notify(|data| {
           ::log::info!("{}", core::str::from_utf8(data).unwrap());

--- a/src/client/ble_remote_characteristic.rs
+++ b/src/client/ble_remote_characteristic.rs
@@ -1,3 +1,5 @@
+use core::borrow::Borrow;
+
 use super::ble_remote_service::BLERemoteServiceState;
 use super::{BLEReader, BLEWriter};
 use crate::{
@@ -27,8 +29,8 @@ bitflags! {
 
 #[allow(clippy::type_complexity)]
 pub struct BLERemoteCharacteristicState {
-  service: WeakUnsafeCell<BLERemoteServiceState>,
-  uuid: BleUuid,
+  pub(crate) service: WeakUnsafeCell<BLERemoteServiceState>,
+  pub(crate) uuid: BleUuid,
   pub handle: u16,
   end_handle: u16,
   properties: GattCharacteristicProperties,
@@ -262,5 +264,26 @@ impl BLERemoteCharacteristic {
       let data = unsafe { core::slice::from_raw_parts((*om).om_data, (*om).om_len as _) };
       no_notify(data);
     }
+  }
+}
+
+impl core::fmt::Display for BLERemoteCharacteristic {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "BLERemoteCharacteristic[{}]", self.state.uuid)
+  }
+}
+
+impl core::fmt::Debug for BLERemoteCharacteristic {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.debug_struct("BLERemoteCharacteristic")
+      .field("uuid", &self.state.uuid)
+      .field(
+        "service",
+        &self.state.service.upgrade().map(|svc| svc.borrow().uuid),
+      )
+      .field("handle", &self.state.handle)
+      .field("end_handle", &self.state.end_handle)
+      .field("properties", &self.state.properties)
+      .finish()
   }
 }

--- a/src/client/ble_remote_service.rs
+++ b/src/client/ble_remote_service.rs
@@ -9,7 +9,7 @@ use core::ffi::c_void;
 
 pub struct BLERemoteServiceState {
   client: WeakUnsafeCell<BLEClientState>,
-  uuid: BleUuid,
+  pub(crate) uuid: BleUuid,
   start_handle: u16,
   pub(crate) end_handle: u16,
   pub(crate) characteristics: Option<Vec<BLERemoteCharacteristic>>,
@@ -104,9 +104,26 @@ impl BLERemoteService {
   }
 }
 
+impl core::fmt::Display for BLERemoteService {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "BLERemoteService[{}]", self.state.uuid)
+  }
+}
+
 impl core::fmt::Debug for BLERemoteService {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    write!(f, "BLERemoteService[{}]", self.state.uuid)?;
-    Ok(())
+    f.debug_struct("BLERemoteService")
+      .field("uuid", &self.state.uuid)
+      .field("start_handle", &self.state.start_handle)
+      .field("end_handle", &self.state.end_handle)
+      .field(
+        "characteristics",
+        &self
+          .state
+          .characteristics
+          .as_ref()
+          .map(|chars| chars.iter().map(|c| c.uuid()).collect::<Vec<_>>()),
+      )
+      .finish()
   }
 }


### PR DESCRIPTION
This allows for easier debugging when working with clients. Debug (`{:?}`) now includes the most valuable fields, and display (`{}`) consists of the `uuid`, and, in the case of the characteristic, `properties`.

Here's an example:

```
I (4039) ble_client: (display) BLERemoteService[0x1812]
I (4039) ble_client: (debug) BLERemoteService { uuid: 0x1812, start_handle: 24, end_handle: 47, characteristics: Some([0x2a4e, 0x2a4d, 0x2a4d, 0x2a4d, 0x2a4b, 0x2a22, 0x2a32, 0x2a4a, 0x2a4c]) }
I (4059) NimBLE: GATT procedure initiated: discover all characteristics;
I (4069) NimBLE: start_handle=48 end_handle=65535
I (4829) ble_client: (display) BLERemoteCharacteristic[f3641401-00b0-4240-ba50-05ca45bf8abc]
I (4829) ble_client: (debug) BLERemoteCharacteristic { uuid: f3641401-00b0-4240-ba50-05ca45bf8abc, service: Some(f3641400-00b0-4240-ba50-05ca45bf8abc), handle: 50, end_handle: 0, properties: GattCharacteristicProperties(READ) }
```

I updated the `ble_client` example to include the change, but I'm unsure if it adds anything to the example.