### PR TITLE
Update espflash command for riscv32

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,7 +22,7 @@ rustflags = ["--cfg", "espidf_time64"] # Extending time_t for ESP IDF 5: https:/
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash --monitor"
+runner = "espflash flash --monitor"
 rustflags = ["--cfg", "espidf_time64", "-C", "default-linker-libraries"]
 
 [target.riscv32imac-esp-espidf]


### PR DESCRIPTION
This is needed for `cargo run` to flash the program on my ESP32-C3.