### PR TITLE
Add warning about the characteristic being locked during `on_write`

### DIFF
--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -135,6 +135,7 @@ impl BLECharacteristic {
     self
   }
 
+  /// This characteristic is locked while the callback is executing. If you call `.lock()` on this characteristic from inside the callback, it will never execute.
   pub fn on_write(
     &mut self,
     callback: impl FnMut(&mut OnWriteArgs) + Send + Sync + 'static,


### PR DESCRIPTION
This caused a lot of confusion for me because I was calling `.lock()` inside the `on_write` callback.