### PR TITLE
Add comments about non-locking behavior of `on_subscribe` function

### DIFF
--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -356,6 +356,7 @@ impl BLECharacteristic {
     }
   }
 
+  /// The characteristic is not locked while the callback is executing. You can call the lock function inside the callback.
   pub fn on_subscribe(
     &mut self,
     callback: impl FnMut(&BLEConnDesc, NimbleSub) + Send + Sync + 'static,


### PR DESCRIPTION
I figured out that `on_subscribe` lets you call `.lock()`, unlike `on_write`. Since they are inconsistent with each other it would be nice to state that in the documentation.