### PR TITLE
The PartialEq implementation for the BLEAddress struct modified

### DIFF
--- a/src/ble_address.rs
+++ b/src/ble_address.rs
@@ -84,7 +84,7 @@ impl core::fmt::Debug for BLEAddress {
 
 impl PartialEq for BLEAddress {
   fn eq(&self, other: &Self) -> bool {
-    self.value.val == other.value.val && self.value.type_ == other.value.type_
+    self.value.val == other.value.val
   }
 }
 


### PR DESCRIPTION
### Description
<!--- Describe the changes introduced by this pull request -->

This pull request modifies the PartialEq implementation for the `BLEAddress` struct. Previously, it compared both the value and the type of the BLE address. However, after careful consideration, it was determined that comparing the type of address is not crucial and might add unnecessary complexity for users. Therefore, this pull request simplifies the comparison by only considering the value of the address.

### Changes Made
<!--- Provide a brief summary of the changes made in this pull request -->

- Modified the `eq` method in the `PartialEq` implementation for `BLEAddress` to only compare the address values.
- Removed the comparison of address types in the `eq` method.

### Benefits
<!--- Explain why these changes are beneficial -->

By focusing solely on comparing the address values, this change simplifies the interface for users of the `BLEAddress` struct. Users no longer need to be concerned about the specific type of the address, leading to a more intuitive and user-friendly API. Additionally, this modification reduces unnecessary complexity and potential confusion.


