### PR TITLE
Add member docs to NimbleProperties

### DIFF
--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -18,17 +18,29 @@ bitflags! {
   #[repr(transparent)]
   #[derive(Debug, Clone, Copy, PartialEq, Eq)]
   pub struct NimbleProperties: u16 {
+    /// Read Access Permitted
     const READ = esp_idf_sys::BLE_GATT_CHR_F_READ as _;
+    /// Read Requires Encryption
     const READ_ENC = esp_idf_sys::BLE_GATT_CHR_F_READ_ENC as _;
+    /// Read requires Authentication
     const READ_AUTHEN = esp_idf_sys::BLE_GATT_CHR_F_READ_AUTHEN as _;
+    /// Read requires Authorization
     const READ_AUTHOR = esp_idf_sys::BLE_GATT_CHR_F_READ_AUTHOR as _;
+    /// Write Permited
     const WRITE = esp_idf_sys::BLE_GATT_CHR_F_WRITE as _;
+    /// Write with no Ack Response
     const WRITE_NO_RSP = esp_idf_sys::BLE_GATT_CHR_F_WRITE_NO_RSP as _;
+    /// Write Requires Encryption
     const WRITE_ENC = esp_idf_sys::BLE_GATT_CHR_F_WRITE_ENC as _;
+    /// Write requires Authentication
     const WRITE_AUTHEN = esp_idf_sys::BLE_GATT_CHR_F_WRITE_AUTHEN as _;
+    /// Write requires Authorization
     const WRITE_AUTHOR = esp_idf_sys::BLE_GATT_CHR_F_WRITE_AUTHOR as _;
+    /// Broadcasts are included in the advertising data
     const BROADCAST = esp_idf_sys::BLE_GATT_CHR_F_BROADCAST as _;
+    /// Notifications are Sent from Server to Client with no Response
     const NOTIFY = esp_idf_sys::BLE_GATT_CHR_F_NOTIFY as _;
+    /// Indications are Sent from Server to Client where Server expects a Response
     const INDICATE = esp_idf_sys::BLE_GATT_CHR_F_INDICATE as _;
   }
 }


### PR DESCRIPTION
This was a stumbling block for me so I added what I could get from other sources. But I have yet to find a definitive Authentication vs Authorization definition (specific to BLE), so I feel like that needs more clarification. It might be useful to add a 'requires key exchange' or something similar.

Might add a usage doc to the struct for those unfamiliar with bitflags.

This is just to start a conversation.

Open to suggestions/corrections.