### PR TITLE
Return BLE_HS_EDONE in characteristic discovery

### DIFF
--- a/src/client/ble_remote_characteristic.rs
+++ b/src/client/ble_remote_characteristic.rs
@@ -157,7 +157,7 @@ impl BLERemoteCharacteristic {
     }
 
     characteristic.state.signal.signal(error.status as _);
-    error.status as _
+    esp_idf_sys::BLE_HS_EDONE as _
   }
 
   extern "C" fn descriptor_disc_cb(


### PR DESCRIPTION
If the characteristic is not the last one in a service `next_char_cb` will be called again with the next characteristic which in the current implementation would override the end handle and would again send the state signal.

The double state signal then leads to `get_descriptors` returning an empty array, can be tested with this sample code:
```rust
let characteristic = service
        .get_characteristic(characteristic_uuid)
        .await
        .unwrap();

    let uuids: Vec<_> = characteristic
        .get_descriptors()
        .await
        .unwrap()
        .map(|d| d.uuid().to_string())
        .collect();
    log::info!("subscribe to {:?}", uuids);
 ```
 
 I haven't found any documentation about what the callback is supposed to return but I found out that returning HS_DONE would not call the callback again. Also Nimble-Arduino also does this so it seems to be correct: https://github.com/wakwak-koba/NimBLE-Arduino/blob/aec7e4294dc2ede1434b68cf8381a307f2c08c68/src/NimBLERemoteCharacteristic.cpp#L216C14-L216C26
 
 