### PR TITLE
# Fix: Update RSSI Field in BLEAdvertisedDevice Structure During Discovery

### DIFF
--- a/src/client/ble_advertised_device.rs
+++ b/src/client/ble_advertised_device.rs
@@ -74,6 +74,10 @@ impl BLEAdvertisedDevice {
     self.rssi
   }
 
+  pub(crate) fn update_rssi(&mut self, rssi: i8) {
+    self.rssi = rssi as i32;
+  }
+
   pub fn get_service_uuids(&self) -> core::slice::Iter<'_, BleUuid> {
     self.service_uuids.iter()
   }

--- a/src/client/ble_scan.rs
+++ b/src/client/ble_scan.rs
@@ -209,6 +209,8 @@ impl BLEScan {
         ::log::debug!("DATA: {:X?}", data);
         advertised_device.parse_advertisement(data);
 
+        advertised_device.update_rssi(disc.rssi);
+
         if let Some(callback) = on_result {
           if scan.scan_params.passive() != 0
             || (advertised_device.adv_type() != AdvType::Ind


### PR DESCRIPTION
## Description

This pull request fixes an issue in the `esp32-nimble` where the `rssi` field of the `BLEAdvertisedDevice` structure was not updated during the discovery process when an advertising report was received.

## Problem

During the BLE discovery process, the Received Signal Strength Indicator (RSSI) value in the `BLEAdvertisedDevice` structure was not being updated properly. This resulted in incorrect or missing RSSI data for discovered devices.

## Solution

The solution involves updating the RSSI field of the `BLEAdvertisedDevice` structure upon receiving an advertising report. The necessary changes have been made to ensure that the RSSI value is correctly captured and updated.

## Additional Notes

Please let me know if there are any additional changes required . I appreciate your review and feedback.

Thank you!