### PR TITLE
Fix cpfd config attribute

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,4 +12,25 @@ fn main() {
   println!("cargo::rustc-check-cfg=cfg(esp_idf_version_patch, values(\"0\"))");
   println!("cargo::rustc-check-cfg=cfg(esp_idf_version_patch, values(\"1\"))");
   println!("cargo::rustc-check-cfg=cfg(esp_idf_version_patch, values(\"2\"))");
+
+  let esp_idf_info = embuild::espidf::sysenv::cfg_args().unwrap();
+  let version: Vec<usize> = ["major", "minor", "patch"]
+    .iter()
+    .filter_map(|ver_part| {
+      let search_string = format!("esp_idf_version_{}", ver_part);
+      esp_idf_info.args.iter().find_map(|arg| {
+        if arg.starts_with(&search_string) {
+          let version_str = arg.split_terminator('"').nth(1).unwrap();
+          Some(version_str.parse::<usize>().unwrap())
+        } else {
+          None
+        }
+      })
+    })
+    .collect();
+
+  println!("cargo::rustc-check-cfg=cfg(cpfd)");
+  if version > vec![5, 2, 0] {
+    println!("cargo::rustc-cfg=cpfd");
+  }
 }

--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -3,11 +3,7 @@ use bitflags::bitflags;
 use core::{cell::UnsafeCell, ffi::c_void};
 use esp_idf_svc::sys;
 
-#[cfg(all(
-  esp_idf_version_major = "5",
-  esp_idf_version_minor = "2",
-  not(esp_idf_version_patch = "0")
-))]
+#[cfg(cpfd)]
 use crate::cpfd::Cpfd;
 
 use crate::{
@@ -131,11 +127,7 @@ pub struct BLECharacteristic {
   svc_def_descriptors: Vec<sys::ble_gatt_dsc_def>,
   subscribed_list: Vec<(u16, NimbleSub)>,
   on_subscribe: Option<Box<dyn FnMut(&Self, &BLEConnDesc, NimbleSub) + Send + Sync>>,
-  #[cfg(all(
-    esp_idf_version_major = "5",
-    esp_idf_version_minor = "2",
-    not(esp_idf_version_patch = "0")
-  ))]
+  #[cfg(cpfd)]
   pub(crate) cpfd: [sys::ble_gatt_cpfd; 2],
 }
 
@@ -153,11 +145,7 @@ impl BLECharacteristic {
       svc_def_descriptors: Vec::new(),
       subscribed_list: Vec::new(),
       on_subscribe: None,
-      #[cfg(all(
-        esp_idf_version_major = "5",
-        esp_idf_version_minor = "2",
-        not(esp_idf_version_patch = "0")
-      ))]
+      #[cfg(cpfd)]
       cpfd: [Default::default(); 2],
     }
   }
@@ -296,11 +284,7 @@ impl BLECharacteristic {
     }
   }
 
-  #[cfg(all(
-    esp_idf_version_major = "5",
-    esp_idf_version_minor = "2",
-    not(esp_idf_version_patch = "0")
-  ))]
+  #[cfg(cpfd)]
   /// Set the Characteristic Presentation Format.
   pub fn cpfd(&mut self, cpfd: Cpfd) {
     if cpfd.name_space == (sys::BLE_GATT_CHR_NAMESPACE_BT_SIG as _) {

--- a/src/server/ble_service.rs
+++ b/src/server/ble_service.rs
@@ -57,11 +57,7 @@ impl BLEService {
               flags: chr.properties.bits(),
               min_key_size: 0,
               val_handle: &mut chr.handle,
-              #[cfg(all(
-                esp_idf_version_major = "5",
-                esp_idf_version_minor = "2",
-                not(esp_idf_version_patch = "0")
-              ))]
+              #[cfg(cpfd)]
               cpfd: chr.cpfd.as_mut_ptr(),
             });
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,11 +34,7 @@ pub use self::ble_server::BLEServer;
 mod ble_service;
 pub use self::ble_service::BLEService;
 
-#[cfg(all(
-  esp_idf_version_major = "5",
-  esp_idf_version_minor = "2",
-  not(esp_idf_version_patch = "0")
-))]
+#[cfg(cpfd)]
 pub mod cpfd;
 
 pub mod hid;


### PR DESCRIPTION
The `cfg(all(...))` gating for the cpfd module, added in #114, is not working for ESP-IDF versions > 5.2.
This patch introduces a new cfg, `cpfd`, that is set from the build script if ESP-IDF version is above 5.2.1. The new cfg is then used to conditionally include the cpfd support.