### PR TITLE
Added connection Handle check before gap event is handled in characteristic to fix the deadlock issue in #151

### DIFF
--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -6,13 +6,13 @@ use esp_idf_svc::sys;
 use zerocopy::IntoBytes;
 
 use crate::{
-  ble,
-  cpfd::Cpfd,
-  utilities::{
-    ble_npl_hw_enter_critical, ble_npl_hw_exit_critical, mutex::Mutex, voidp_to_ref, BleUuid,
-    OsMBuf,
-  },
-  AttValue, BLEConnDesc, BLEDescriptor, BLEDevice, BLEError, DescriptorProperties, OnWriteArgs,
+    ble,
+    cpfd::Cpfd,
+    utilities::{
+        ble_npl_hw_enter_critical, ble_npl_hw_exit_critical, mutex::Mutex, voidp_to_ref, BleUuid,
+        OsMBuf,
+    },
+    AttValue, BLEConnDesc, BLEDescriptor, BLEDevice, BLEError, DescriptorProperties, OnWriteArgs,
 };
 
 cfg_if::cfg_if! {
@@ -318,72 +318,83 @@ impl BLECharacteristic {
     let ctxt = unsafe { &*ctxt };
 
     let mutex = unsafe { voidp_to_ref::<Mutex<Self>>(arg) };
-    let Some(mut characteristic) = mutex.try_lock() else {
-      return sys::BLE_ATT_ERR_UNLIKELY as _;
-    };
 
-    if unsafe { sys::ble_uuid_cmp((*ctxt.__bindgen_anon_1.chr).uuid, &characteristic.uuid.u) != 0 }
-    {
-      return sys::BLE_ATT_ERR_UNLIKELY as _;
-    }
+    match crate::utilities::ble_gap_conn_find(conn_handle) {
+      Ok(_) => {
+        let mut characteristic = mutex.lock();
+        println!("{:?}", conn_handle);
 
-    match ctxt.op as _ {
-      sys::BLE_GATT_ACCESS_OP_READ_CHR => {
-        let desc = crate::utilities::ble_gap_conn_find(conn_handle).unwrap();
-
-        unsafe {
-          if (*(ctxt.om)).om_pkthdr_len > 8 || characteristic.value.len() <= (desc.mtu() - 3) as _ {
-            let characteristic = UnsafeCell::new(&mut characteristic);
-            if let Some(callback) = &mut (*characteristic.get()).on_read {
-              callback(*characteristic.get(), &desc);
-            }
-          }
+        if unsafe {
+          sys::ble_uuid_cmp((*ctxt.__bindgen_anon_1.chr).uuid, &characteristic.uuid.u) != 0
+        } {
+          return sys::BLE_ATT_ERR_UNLIKELY as _;
         }
 
-        ble_npl_hw_enter_critical();
-        let value = characteristic.value.as_slice();
-        let rc = OsMBuf(ctxt.om).append(value);
-        ble_npl_hw_exit_critical();
-        if rc == 0 {
-          0
-        } else {
-          sys::BLE_ATT_ERR_INSUFFICIENT_RES as _
-        }
-      }
-      sys::BLE_GATT_ACCESS_OP_WRITE_CHR => {
-        let om = OsMBuf(ctxt.om);
-        let buf = om.as_flat();
-
-        let mut notify = false;
-
-        unsafe {
-          let characteristic = UnsafeCell::new(&mut characteristic);
-          if let Some(callback) = &mut (*characteristic.get()).on_write {
+        match ctxt.op as _ {
+          sys::BLE_GATT_ACCESS_OP_READ_CHR => {
             let desc = crate::utilities::ble_gap_conn_find(conn_handle).unwrap();
-            let mut arg = OnWriteArgs {
-              current_data: (*characteristic.get()).value.as_slice(),
-              recv_data: buf.as_slice(),
-              desc: &desc,
-              reject: false,
-              error_code: 0,
-              notify: false,
-            };
-            callback(&mut arg);
 
-            if arg.reject {
-              return arg.error_code as _;
+            unsafe {
+              if (*(ctxt.om)).om_pkthdr_len > 8
+                || characteristic.value.len() <= (desc.mtu() - 3) as _
+              {
+                let characteristic = UnsafeCell::new(&mut characteristic);
+                if let Some(callback) = &mut (*characteristic.get()).on_read {
+                  callback(*characteristic.get(), &desc);
+                }
+              }
             }
-            notify = arg.notify;
-          }
-        }
-        characteristic.set_value(buf.as_slice());
-        if notify {
-          characteristic.notify();
-        }
 
-        0
+            ble_npl_hw_enter_critical();
+            let value = characteristic.value.as_slice();
+            let rc = OsMBuf(ctxt.om).append(value);
+            ble_npl_hw_exit_critical();
+            if rc == 0 {
+              0
+            } else {
+              sys::BLE_ATT_ERR_INSUFFICIENT_RES as _
+            }
+          }
+          sys::BLE_GATT_ACCESS_OP_WRITE_CHR => {
+            let om = OsMBuf(ctxt.om);
+            let buf = om.as_flat();
+
+            let mut notify = false;
+
+            unsafe {
+              let characteristic = UnsafeCell::new(&mut characteristic);
+              if let Some(callback) = &mut (*characteristic.get()).on_write {
+                let desc = crate::utilities::ble_gap_conn_find(conn_handle).unwrap();
+                let mut arg = OnWriteArgs {
+                  current_data: (*characteristic.get()).value.as_slice(),
+                  recv_data: buf.as_slice(),
+                  desc: &desc,
+                  reject: false,
+                  error_code: 0,
+                  notify: false,
+                };
+                callback(&mut arg);
+
+                if arg.reject {
+                  return arg.error_code as _;
+                }
+                notify = arg.notify;
+              }
+            }
+            characteristic.set_value(buf.as_slice());
+            if notify {
+              characteristic.notify();
+            }
+
+            0
+          }
+          _ => sys::BLE_ATT_ERR_UNLIKELY as _,
+        }
       }
-      _ => sys::BLE_ATT_ERR_UNLIKELY as _,
+      Err(_) => {
+        println!("the conn handle does not exist");
+        return sys::BLE_ATT_ERR_UNLIKELY as _;
+      }
     }
   }
 


### PR DESCRIPTION
The handle_gap_event that lead to deadlocks where an invalid connection handle 65535 would occur after a failed notify ( no clue what caused that to occur). 
The connection handle value was 65535(highest value for u16) which is an invalid conn_handle (unless someone somehow managed to connect that many devices).

The `try_lock() `worked as a stop gap but it would lead to failed read/write attempts when notify was in progress which would lead to disconnection.

