### PR TITLE
Fix set_indicate_wait: actually reserve the in-flight slot

### DIFF
--- a/src/server/ble_server.rs
+++ b/src/server/ble_server.rs
@@ -479,8 +479,25 @@ rx_time={}
         0
     }
 
-    pub(super) fn set_indicate_wait(&self, conn_handle: u16) -> bool {
-        !self.indicate_wait.contains(&conn_handle)
+    /// Reserve the single-indication-in-flight slot for `conn_handle`.
+    /// Returns `true` if the slot was free and is now held by this conn.
+    /// Returns `false` if another indication on this conn is already pending.
+    pub(super) fn set_indicate_wait(&mut self, conn_handle: u16) -> bool {
+        if self.indicate_wait.contains(&conn_handle) {
+            return false;
+        }
+        if let Some(slot) = self
+            .indicate_wait
+            .iter_mut()
+            .find(|x| **x == BLE_HS_CONN_HANDLE_NONE)
+        {
+            *slot = conn_handle;
+            true
+        } else {
+            // No free slot for a new connection - shouldn't happen since
+            // indicate_wait is sized to MAX_CONNECTIONS.
+            false
+        }
     }
 
     pub(super) fn clear_indicate_wait(&mut self, conn_handle: u16) {


### PR DESCRIPTION
## Summary

`BLEServer::set_indicate_wait` is currently a read-only predicate — it checks whether `conn_handle` is not already in `indicate_wait[]`, but never writes to the array. Since no other writer exists in the crate (search: `grep indicate_wait`), the slots stay at `BLE_HS_CONN_HANDLE_NONE` indefinitely, and the "one indication in flight per connection" gate in `send_value` is permanently disarmed.

## The bug

Current code (`src/server/ble_server.rs`):

\`\`\`rust
pub(super) fn set_indicate_wait(&self, conn_handle: u16) -> bool {
    !self.indicate_wait.contains(&conn_handle)
}
\`\`\`

This returns \`true\` on first call (slot is empty, so \`contains\` is \`false\`), logging \"OK to send indication\" to the caller. It also returns \`true\` on every subsequent call for the same conn_handle because the array still doesn't actually contain it. Meanwhile the NimBLE C stack's own \"indicate_val_handle\" tracking is what actually enforces serial indications, but that's not observable here.

\`clear_indicate_wait\` is correctly implemented (it writes \`BLE_HS_CONN_HANDLE_NONE\` back to the slot), and is called from the \`NOTIFY_TX\` event handler for indications, but since nothing ever set a non-\`NONE\` value, the clear is effectively a no-op.

## Fix

Correct behavior:
- If \`conn_handle\` is already present → return \`false\` (busy for this conn).
- Else find the first free slot (\`BLE_HS_CONN_HANDLE_NONE\`) and write \`conn_handle\` into it; return \`true\`.
- If no free slot exists (shouldn't happen since the array is sized to \`MAX_CONNECTIONS\`), return \`false\`.

Needs \`&mut self\` to mutate. Call sites already hit \`get_server() -> &'static mut BLEServer\`, so no downstream changes.

## How I found this

Debugging an FTMS Control Point indication flow with a GATT server on ESP32-C6. With the gate broken, duplicate indications to the same conn were silently queued into the NimBLE C backend, consuming mbufs beyond the intended one-in-flight limit. Took a while to notice because the C-level \`indicate_val_handle\` gate normally covers for it — but when combined with other test conditions (see firmware-side bug we hit separately), the mbuf pool could be exhausted.

Found by reading `src/server/ble_server.rs`:482 while chasing a different issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)