### PR TITLE
Add ESP-IDF v6.0 support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,11 +7,12 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(esp_idf_soc_esp_nimble_controller)");
     println!("cargo::rustc-check-cfg=cfg(esp_idf_bt_nimble_ext_adv)");
 
-    println!(r#"cargo::rustc-check-cfg=cfg(esp_idf_version_major, values("4", "5"))"#);
+    println!(r#"cargo::rustc-check-cfg=cfg(esp_idf_version_major, values("4", "5", "6"))"#);
     println!(
         r#"cargo::rustc-check-cfg=cfg(esp_idf_version_minor, values("1", "2", "3", "4", "5"))"#
     );
     println!(r#"cargo::rustc-check-cfg=cfg(esp_idf_version_patch, values("0", "1", "2"))"#);
+    println!("cargo::rustc-check-cfg=cfg(esp_idf_version_at_least_5_4_2)");
 
     let esp_idf_info = embuild::espidf::sysenv::cfg_args().unwrap();
     let version: Vec<usize> = ["major", "minor", "patch"]

--- a/src/server/ble_characteristic.rs
+++ b/src/server/ble_characteristic.rs
@@ -31,6 +31,7 @@ cfg_if::cfg_if! {
     all(
       esp_idf_version_major = "5",
       esp_idf_version_minor = "5"),
+    esp_idf_version_major = "6",
   ))] {
     type NotifyTxType = sys::ble_gap_event__bindgen_ty_1__bindgen_ty_12;
     type Subscribe = sys::ble_gap_event__bindgen_ty_1__bindgen_ty_13;
@@ -51,7 +52,8 @@ cfg_if::cfg_if! {
     all(
       esp_idf_version_major = "5",
       esp_idf_version_minor = "5",
-    )
+    ),
+    esp_idf_version_major = "6",
   ))] {
     type NimblePropertiesType = u32;
   } else {
@@ -88,24 +90,15 @@ bitflags! {
     /// Indications are Sent from Server to Client where Server expects a Response
     const INDICATE = sys::BLE_GATT_CHR_F_INDICATE as _;
 
-    #[cfg(all(
-      esp_idf_version_major = "5",
-      esp_idf_version_minor = "4",
-      not(any(esp_idf_version_patch = "0", esp_idf_version_patch = "1"))))]
+    #[cfg(esp_idf_version_at_least_5_4_2)]
     /// CCCD Write Encrypted
     const NOTIFY_INDICATE_ENC = sys::BLE_GATT_CHR_F_NOTIFY_INDICATE_ENC as _;
 
-    #[cfg(all(
-      esp_idf_version_major = "5",
-      esp_idf_version_minor = "4",
-      not(any(esp_idf_version_patch = "0", esp_idf_version_patch = "1"))))]
+    #[cfg(esp_idf_version_at_least_5_4_2)]
     /// CCCD Write Authenticated
     const NOTIFY_INDICATE_AUTHEN = sys::BLE_GATT_CHR_F_NOTIFY_INDICATE_AUTHEN as _;
 
-    #[cfg(all(
-      esp_idf_version_major = "5",
-      esp_idf_version_minor = "4",
-      not(any(esp_idf_version_patch = "0", esp_idf_version_patch = "1"))))]
+    #[cfg(esp_idf_version_at_least_5_4_2)]
     /// CCCD Write Authorized
     const NOTIFY_INDICATE_AUTHOR = sys::BLE_GATT_CHR_F_NOTIFY_INDICATE_AUTHOR  as _;
   }


### PR DESCRIPTION
Adds the necessary version cfg to compile against IDF v6.0. Also uses `esp_idf_version_at_least_5_4_2` value which has been emitted by `esp-idf-sys` since 0.37.

Verified building on esp32s3 against the following pins:
```toml
[patch.crates-io]
esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys", rev = "8369f610a31e9c90a5479ed7f366f983589dfa0a" }
esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal", rev = "f1bac2d93fe9e92a1df2ad0acd34ef702a791ba4" }
esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc", rev = "f59ffada5638cf582fe8cab1771fa38873ef6d73" }
```

I also did a quick runtime test running in server role and seemed to be fine.